### PR TITLE
show simple loading indicator while loading data for graph

### DIFF
--- a/app/source-fenix6/DeviceView.mc
+++ b/app/source-fenix6/DeviceView.mc
@@ -21,4 +21,8 @@ class DeviceView {
             Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER
         );
     }
+
+    function drawProgressIndicator(dc as Dc, progress as Float) as Void {
+        dc.drawArc(dc.getWidth() / 2, dc.getHeight() / 2, dc.getHeight() / 2, Graphics.ARC_CLOCKWISE, 0, progress);
+    }
 }

--- a/app/source-instinct2/DeviceView.mc
+++ b/app/source-instinct2/DeviceView.mc
@@ -23,4 +23,8 @@ class DeviceView {
             Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER
         );
     }
+
+    function drawProgressIndicator(dc as Dc, progress as Float) as Void {
+        dc.drawArc(144, 31, 31, Graphics.ARC_CLOCKWISE, 0, progress);
+    }
 }

--- a/app/source-instinct2s/DeviceView.mc
+++ b/app/source-instinct2s/DeviceView.mc
@@ -23,4 +23,8 @@ class DeviceView {
             Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER
         );
     }
+
+    function drawProgressIndicator(dc as Dc, progress as Float) as Void {
+        dc.drawArc(136, 27, 27, Graphics.ARC_CLOCKWISE, 0, progress);
+    }
 }

--- a/app/source/BatteryGuesstimateView.mc
+++ b/app/source/BatteryGuesstimateView.mc
@@ -20,6 +20,12 @@ class BatteryGuesstimateView extends WatchUi.View {
         _drawingDone = false;
         _dataPos = DATA_POS_START;
     }
+
+    // only for tests
+    public function getGraphData() as Array {
+        return _graphData;
+    }
+
     //! Constructor
     public function initialize() {
         WatchUi.View.initialize();
@@ -63,7 +69,6 @@ class BatteryGuesstimateView extends WatchUi.View {
                 Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER
             );
             return;
-
         }
         if (_dataPos >= 0) {
             dc.setPenWidth(20);
@@ -78,7 +83,7 @@ class BatteryGuesstimateView extends WatchUi.View {
             var progress = 360.0/GRAPH_WIDTH*(GRAPH_WIDTH-_dataPos)*-1;
             dc.drawArc(144, 31, 31, Graphics.ARC_CLOCKWISE, 0, progress);
 
-            _graphData[_dataPos] = getGraphData(_stepsToShowInGraph, _dataPos);
+            _graphData[_dataPos] = getBatteryData(_stepsToShowInGraph, _dataPos);
             _dataPos -= 1;
             WatchUi.requestUpdate();
 
@@ -109,7 +114,7 @@ class BatteryGuesstimateView extends WatchUi.View {
     }
 
     // placed in a seperate function to make it testable
-    public function getGraphData(stepsToShowInGraph as Integer, x as Integer) as Float? {
+    public function getBatteryData(stepsToShowInGraph as Integer, x as Integer) as Float? {
         var batteryValue = 0;
 
         var stepsPerPixelX = stepsToShowInGraph / GRAPH_WIDTH; // for now it must be dividable by 96

--- a/app/source/BatteryGuesstimateView.mc
+++ b/app/source/BatteryGuesstimateView.mc
@@ -7,8 +7,9 @@ import Toybox.Math;
 
 const GRAPH_WIDTH = 96; // maximum amount of data points we can show in the graph
 class BatteryGuesstimateView extends WatchUi.View {
-    private var _drawingDone as Boolean = false;
     var _stepsToShowInGraph as Integer = GRAPH_WIDTH;
+    private var _showLoadingIndicator as Boolean = true;
+    private var _drawingDone as Boolean = false;
     //! Constructor
     public function initialize() {
         WatchUi.View.initialize();
@@ -22,6 +23,7 @@ class BatteryGuesstimateView extends WatchUi.View {
 
     //! Restore the state of the app and prepare the view to be shown
     public function onShow() as Void {
+        _showLoadingIndicator = true;
         _drawingDone = false;
     }
 
@@ -37,6 +39,7 @@ class BatteryGuesstimateView extends WatchUi.View {
         } else {
             _stepsToShowInGraph = steps;
         }
+        _showLoadingIndicator = true;
         _drawingDone = false;
         WatchUi.requestUpdate();
     }
@@ -44,11 +47,24 @@ class BatteryGuesstimateView extends WatchUi.View {
     //! Update the view
     //! @param dc Device Context
     public function onUpdate(dc as Dc) as Void {
-        if (_drawingDone == false) {
+        dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_BLACK);
+        if (_showLoadingIndicator == true) {
+            _showLoadingIndicator = false;
+            dc.clear();
+            dc.drawText(
+                dc.getWidth() / 2, (dc.getHeight() / 2) + 10,
+                Graphics.FONT_LARGE,
+                "loading ...",
+                Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER
+            );
+            WatchUi.requestUpdate();
+            return;
+        } else if (_drawingDone == false) {
+            dc.clear();
             var deviceSpecificView = new DeviceView();
             var timeText = "24h";
             View.onUpdate(dc);
-            dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_BLACK);
+
             deviceSpecificView.drawButtonHint(dc);
             var graphData = getGraphData(_stepsToShowInGraph);
             var x;

--- a/app/source/BatteryGuesstimateView.mc
+++ b/app/source/BatteryGuesstimateView.mc
@@ -83,7 +83,7 @@ class BatteryGuesstimateView extends WatchUi.View {
                 Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER
             );
             var progress = 360.0/GRAPH_WIDTH*(GRAPH_WIDTH-_dataPos)*-1;
-            deviceSpecificView.drawProgressIndicator(dc, progress);
+            deviceSpecificView.drawProgressIndicator(dc, progress as Float);
 
             _graphData[_dataPos] = getBatteryData(_stepsToShowInGraph, _dataPos);
             _dataPos -= 1;

--- a/app/source/BatteryGuesstimateView.mc
+++ b/app/source/BatteryGuesstimateView.mc
@@ -61,6 +61,8 @@ class BatteryGuesstimateView extends WatchUi.View {
     //! Update the view
     //! @param dc Device Context
     public function onUpdate(dc as Dc) as Void {
+        var deviceSpecificView = new DeviceView();
+
         if (_circularBufferPosition == null) {
             dc.drawText(
                 dc.getWidth() / 2, (dc.getHeight() / 2) + 10,
@@ -81,7 +83,7 @@ class BatteryGuesstimateView extends WatchUi.View {
                 Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER
             );
             var progress = 360.0/GRAPH_WIDTH*(GRAPH_WIDTH-_dataPos)*-1;
-            dc.drawArc(144, 31, 31, Graphics.ARC_CLOCKWISE, 0, progress);
+            deviceSpecificView.drawProgressIndicator(dc, progress);
 
             _graphData[_dataPos] = getBatteryData(_stepsToShowInGraph, _dataPos);
             _dataPos -= 1;
@@ -90,7 +92,6 @@ class BatteryGuesstimateView extends WatchUi.View {
             return;
         } else if (_drawingDone == false ) {
             dc.setPenWidth(1);
-            var deviceSpecificView = new DeviceView();
             var timeText = "24h";
             View.onUpdate(dc);
 

--- a/tests/source/BatteryGuesstimateViewTests.mc
+++ b/tests/source/BatteryGuesstimateViewTests.mc
@@ -3,89 +3,121 @@ import Toybox.Math;
 import Toybox.Application.Storage;
 import Toybox.Lang;
 import Toybox.System;
+using Toybox.Graphics;
+
+function getDc() as Graphics.Dc {
+    var buffer = new Graphics.BufferedBitmap({:width=>162, :height=>162});
+    return buffer.getDc();
+}
 
 (:test)
-function getGraphDataOneDay(logger as Logger) as Boolean {
+function onUpdateTestOneDay(logger as Logger) as Boolean {
     var view = new BatteryGuesstimateView();
     Storage.clearValues();
     Storage.setValue("cBlP", 100);
     for (var i = 0; i<=100; i++) {
         Storage.setValue(i, i+0.123);
     }
-    var graphData = view.getGraphData(96);
+    view.onShow();
+    // simulate what WatchUi.requestUpdate() will hopefully do
+    for (var i = 0; i<96; i++) {
+        view.onUpdate(getDc());
+    }
+    var graphData = view.getGraphData();
     Test.assertEqualMessage(graphData.size(), 96, "getGraphData should return an array of 96 values");
     for (var i = 0; i<96; i++) {
         var expected = i + 5.123 as Float;
-        assertEqualFloat(logger, graphData[i], expected);
+        assertEqualFloat(logger, graphData[i] as Float, expected);
     }
-    
     return true;
 }
 
 (:test)
-function getGraphDataTwoWeeks(logger as Logger) as Boolean {
+function onUpdateTestTwoWeeks(logger as Logger) as Boolean {
     var view = new BatteryGuesstimateView();
     Storage.clearValues();
     Storage.setValue("cBlP", 1344);
     for (var i = 0; i<SIZE_CIRCULAR_BUFFER; i++) {
         Storage.setValue(i, i.toFloat()/15);
     }
-    var graphData = view.getGraphData(1344);
+    view.onShow();
+    view.setStepsToShowInGraph(1344);
+    // simulate what WatchUi.requestUpdate() will hopefully do
+    for (var i = 0; i<96; i++) {
+        view.onUpdate(getDc());
+    }
+    var graphData = view.getGraphData();
     Test.assertEqualMessage(graphData.size(), 96, "getGraphData should return an array of 96 values");
-    assertEqualFloat(logger, graphData[95], 89.166672);
-    assertEqualFloat(logger, graphData[0], 0.50);
-    
+    assertEqualFloat(logger, graphData[95] as Float, 89.166672);
+    assertEqualFloat(logger, graphData[0] as Float, 0.50);
     return true;
 }
 
 (:test)
-function getGraphDataRollingOverBufferEnd(logger as Logger) as Boolean {
+function onUpdateTestRollingOverBufferEnd(logger as Logger) as Boolean {
     var view = new BatteryGuesstimateView();
     Storage.clearValues();
     Storage.setValue("cBlP", 500);
     for (var i = 0; i<SIZE_CIRCULAR_BUFFER; i++) {
         Storage.setValue(i, i.toFloat()/15);
     }
-    var graphData = view.getGraphData(1344);
+    view.onShow();
+    view.setStepsToShowInGraph(1344);
+    // simulate what WatchUi.requestUpdate() will hopefully do
+    for (var i = 0; i<96; i++) {
+        view.onUpdate(getDc());
+    }
+    var graphData = view.getGraphData();
     Test.assertEqualMessage(graphData.size(), 96, "getGraphData should return an array of 96 values");
-    assertEqualFloat(logger, graphData[95], 32.9);
-    assertEqualFloat(logger, graphData[0], 33.899998);
-
+    assertEqualFloat(logger, graphData[95] as Float, 32.9);
+    assertEqualFloat(logger, graphData[0] as Float, 33.899998);
     return true;
 }
 
 (:test)
-function getGraphDataNoData(logger as Logger) as Boolean {
+function onUpdateTestNoData(logger as Logger) as Boolean {
     var view = new BatteryGuesstimateView();
     Storage.clearValues();
-    var graphData = view.getGraphData(1344);
-    if (graphData != null) {
-        logger.error("getGraphData should return null");
+    view.onShow();
+    view.setStepsToShowInGraph(1344);
+    view.onUpdate(getDc());
+    var graphData = view.getGraphData();
+    Test.assertEqualMessage(graphData.size(), 96, "getGraphData should return an array of 96 values");
+    if (graphData[0] != null || graphData[95] != null) {
+        logger.error("content of graphData should return null");
         return false;
     }
-
     return true;
 }
 
 (:test)
-function getGraphDataNotEnoughData(logger as Logger) as Boolean {
+function onUpdateTestNotEnoughData(logger as Logger) as Boolean {
     var view = new BatteryGuesstimateView();
     Storage.clearValues();
     Storage.setValue("cBlP", 5);
     for (var i = 0; i<=5; i++) {
         Storage.setValue(i, 15.0);
     }
-    var graphData = view.getGraphData(96);
-    assertEqualFloat(logger, graphData[95], 15.0);
-    assertEqualFloat(logger, graphData[94], 15.0);
-    assertEqualFloat(logger, graphData[90], 15.0);
-    assertEqualFloat(logger, graphData[89], 0.0);
-    assertEqualFloat(logger, graphData[0], 0.0);
+    view.onShow();
+    view.setStepsToShowInGraph(96);
+    // simulate what WatchUi.requestUpdate() will hopefully do
+    for (var i = 0; i<96; i++) {
+        view.onUpdate(getDc());
+    }
+    var graphData = view.getGraphData();
+    assertEqualFloat(logger, graphData[95] as Float, 15.0);
+    assertEqualFloat(logger, graphData[94] as Float, 15.0);
+    assertEqualFloat(logger, graphData[90] as Float, 15.0);
+    assertEqualFloat(logger, graphData[89] as Float, 0.0);
+    assertEqualFloat(logger, graphData[0] as Float, 0.0);
 
-    graphData = view.getGraphData(384);
-    assertEqualFloat(logger, graphData[95], 15.0);
-    assertEqualFloat(logger, graphData[94], 7.50);
-    assertEqualFloat(logger, graphData[93], 0.0);
-
+    view.setStepsToShowInGraph(384);
+    for (var i = 0; i<96; i++) {
+        view.onUpdate(getDc());
+    }
+    graphData = view.getGraphData();
+    assertEqualFloat(logger, graphData[95] as Float, 15.0);
+    assertEqualFloat(logger, graphData[94] as Float, 7.50);
+    assertEqualFloat(logger, graphData[93] as Float, 0.0);
     return true;
 }


### PR DESCRIPTION
loading the graph can take a while, so show a simple loading indicator
because it's impossible to get out of a function and call `onUpdate()` while the function is working there was some refactoring needed
now it's not the `getGraphData` function doing the looping but `onUpdate()` calls itself (by using `WatchUi.requestUpdate();`) till the reading of all the data is done 