### PR TITLE
remove the logic for avoiding draving twice

### DIFF
--- a/app/source/BatteryGuesstimateDetailsView.mc
+++ b/app/source/BatteryGuesstimateDetailsView.mc
@@ -7,7 +7,6 @@ class BatteryGuesstimateDetailsView extends WatchUi.View {
     private var _minutes as Integer;
     private var _battChangeInPercent as Float;
     private var _guesstimate as Integer?;
-    private var _drawingDone as Boolean = false;
 
     //! Constructor
     public function initialize() {
@@ -36,54 +35,49 @@ class BatteryGuesstimateDetailsView extends WatchUi.View {
 
     //! Restore the state of the app and prepare the view to be shown
     public function onShow() as Void {
-        _drawingDone = false;
     }
 
     public function setMessage(minutes as Integer, batteryChangeInPercent as Float, guesstimate as Integer?) as Void {
         _minutes = minutes;
         _battChangeInPercent = batteryChangeInPercent;
         _guesstimate = guesstimate;
-        _drawingDone = false;
         WatchUi.requestUpdate();
     }
     //! Update the view
     //! @param dc Device Context
     public function onUpdate(dc as Dc) as Void { 
-        if (_drawingDone == false) {
-            var deviceSpecificView = new DeviceView();
-            dc.clear();
-            dc.setPenWidth(1);
-            View.onUpdate(dc);
-            dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_BLACK);
+        var deviceSpecificView = new DeviceView();
+        dc.clear();
+        dc.setPenWidth(1);
+        View.onUpdate(dc);
+        dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_BLACK);
 
-            var time;
-            time = $.timePeriodFormat(_minutes, true);
+        var time;
+        time = $.timePeriodFormat(_minutes, true);
 
-            deviceSpecificView.drawButtonHint(dc);
+        deviceSpecificView.drawButtonHint(dc);
 
-            var deviceSpecificDetailsView = new DeviceDetailsView();
-            dc.drawText(
-                deviceSpecificDetailsView.X_POS_TIME,
-                deviceSpecificDetailsView.Y_POS_TIME,
-                Graphics.FONT_LARGE, time, Graphics.TEXT_JUSTIFY_LEFT
-            );
+        var deviceSpecificDetailsView = new DeviceDetailsView();
+        dc.drawText(
+            deviceSpecificDetailsView.X_POS_TIME,
+            deviceSpecificDetailsView.Y_POS_TIME,
+            Graphics.FONT_LARGE, time, Graphics.TEXT_JUSTIFY_LEFT
+        );
 
-            dc.drawText(
-                deviceSpecificDetailsView.X_POS_DATA,
-                deviceSpecificDetailsView.Y_POS_BATT_CHANGE_IN_PERCENT,
-                Graphics.FONT_MEDIUM,
-                $.formatOutput(_battChangeInPercent),
-                Graphics.TEXT_JUSTIFY_LEFT|Graphics.TEXT_JUSTIFY_VCENTER
-            );
-            dc.drawText(
-                deviceSpecificDetailsView.X_POS_DATA,
-                deviceSpecificDetailsView.Y_POS_BATT_GUESSTIMATE,
-                Graphics.FONT_MEDIUM,
-                $.guesstimateFormat(_guesstimate),
-                Graphics.TEXT_JUSTIFY_LEFT|Graphics.TEXT_JUSTIFY_VCENTER
-            );
-            _drawingDone = true;
-        }
+        dc.drawText(
+            deviceSpecificDetailsView.X_POS_DATA,
+            deviceSpecificDetailsView.Y_POS_BATT_CHANGE_IN_PERCENT,
+            Graphics.FONT_MEDIUM,
+            $.formatOutput(_battChangeInPercent),
+            Graphics.TEXT_JUSTIFY_LEFT|Graphics.TEXT_JUSTIFY_VCENTER
+        );
+        dc.drawText(
+            deviceSpecificDetailsView.X_POS_DATA,
+            deviceSpecificDetailsView.Y_POS_BATT_GUESSTIMATE,
+            Graphics.FONT_MEDIUM,
+            $.guesstimateFormat(_guesstimate),
+            Graphics.TEXT_JUSTIFY_LEFT|Graphics.TEXT_JUSTIFY_VCENTER
+        );
     }
 
     //! Called when this View is removed from the screen. Save the

--- a/app/source/BatteryGuesstimateView.mc
+++ b/app/source/BatteryGuesstimateView.mc
@@ -10,7 +10,6 @@ const GRAPH_WIDTH = 96; // maximum amount of data points we can show in the grap
 const DATA_POS_START = GRAPH_WIDTH-1;
 class BatteryGuesstimateView extends WatchUi.View {
     var _stepsToShowInGraph as Integer = GRAPH_WIDTH;
-    private var _drawingDone as Boolean = false;
     private var _graphData as Array = new [GRAPH_WIDTH];
     private var _dataPos as Integer = DATA_POS_START;
     private var _circularBufferPosition as Integer = 0;
@@ -24,7 +23,6 @@ class BatteryGuesstimateView extends WatchUi.View {
 
     private function resetValues() as Void {
         _circularBufferPosition = Storage.getValue($.CIRCULAR_BUFFER_LAST_POSITION_STORAGE_NAME_V2) as Integer;
-        _drawingDone = false;
         _dataPos = DATA_POS_START;
         _minBattValue = 100.0;
         _maxBattValue = 0.0;
@@ -153,137 +151,136 @@ class BatteryGuesstimateView extends WatchUi.View {
             WatchUi.requestUpdate();
 
             return;
-        } else if (_drawingDone == false ) {
-            dc.setPenWidth(1);
-            var timeText = "24h";
-            View.onUpdate(dc);
+        }
+        
+        dc.setPenWidth(1);
+        var timeText = "24h";
+        View.onUpdate(dc);
 
-            _deviceSpecificView.drawButtonHint(dc);
-            try {
-                if (!(Properties.getValue("export-url") as String).equals("")) {
-                    _deviceSpecificView.drawExportButtonHint(dc);
-                }
-            } catch (e){
-                // key does not exist, so nothing to do
+        _deviceSpecificView.drawButtonHint(dc);
+        try {
+            if (!(Properties.getValue("export-url") as String).equals("")) {
+                _deviceSpecificView.drawExportButtonHint(dc);
             }
+        } catch (e){
+            // key does not exist, so nothing to do
+        }
 
-            var x;
+        var x;
 
-            for (var i = GRAPH_WIDTH-1; i >= 0; i -= 1) {
-                x = i * _deviceSpecificView.GRAPH_WIDTH_MULTIPLIER + _deviceSpecificView.X_MARGIN_LEFT;
-                var graphData = Math.round(_graphData[i] as Float / 2);
-                dc.drawLine(
-                    x,
-                    _deviceSpecificView.Y_ZERO_LINE,
-                    x,
-                    _deviceSpecificView.Y_ZERO_LINE-graphData  as Float * _deviceSpecificView.GRAPH_WIDTH_MULTIPLIER
-                );
-            }
-            _drawingDone = true;
-
-            if (_stepsToShowInGraph > 96) {
-                timeText = (_stepsToShowInGraph / 96) + "days";
-            }
-
-            _deviceSpecificView.drawTimeText(dc, timeText);
-            var guesstimate = $.guesstimate(_cumulatedDischarge*-1, _stepsToShowInGraph * 15);
-            var y = _deviceSpecificView.STATS_Y_START;
-
-            dc.drawText(
-                _deviceSpecificView.STATS_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                _maxBattValue.format("%0.2f") + "%",
-                Graphics.TEXT_JUSTIFY_RIGHT
-            );
-            y = y + _deviceSpecificView.STATS_LINE_HIGHT;
-            dc.drawText(
-                _deviceSpecificView.STATS_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                _minBattValue.format("%0.2f") + "%",
-                Graphics.TEXT_JUSTIFY_RIGHT
-            );
-
-            y = y + _deviceSpecificView.STATS_LINE_HIGHT + _deviceSpecificView.STATS_GROUP_PADDING;
-            dc.drawText(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                 "+",
-                 Graphics.TEXT_JUSTIFY_LEFT);
-            dc.drawText(
-                _deviceSpecificView.STATS_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                _cumulatedCharge.format("%0.2f") + "%",
-                Graphics.TEXT_JUSTIFY_RIGHT
-            );
-
-            y = y + _deviceSpecificView.STATS_LINE_HIGHT;
-            dc.drawText(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                "-",
-                Graphics.TEXT_JUSTIFY_LEFT
-            );
-            dc.drawText(
-                _deviceSpecificView.STATS_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                _cumulatedDischarge.format("%0.2f") + "%",
-                Graphics.TEXT_JUSTIFY_RIGHT
-            );
-
-            y = y + _deviceSpecificView.STATS_LINE_HIGHT + _deviceSpecificView.STATS_GROUP_PADDING;
-            dc.drawText(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                "->",
-                Graphics.TEXT_JUSTIFY_LEFT
-            );
-            dc.drawText(
-                _deviceSpecificView.STATS_X_ALLINGMENT,
-                y,
-                _deviceSpecificView.STATS_FONT,
-                $.guesstimateFormat(guesstimate),
-                Graphics.TEXT_JUSTIFY_RIGHT
-            );
-
-            // draw min/max symbol
+        for (var i = GRAPH_WIDTH-1; i >= 0; i -= 1) {
+            x = i * _deviceSpecificView.GRAPH_WIDTH_MULTIPLIER + _deviceSpecificView.X_MARGIN_LEFT;
+            var graphData = Math.round(_graphData[i] as Float / 2);
             dc.drawLine(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+3,
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT+3
-            );
-            dc.drawLine(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+6,
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP
-            );
-            dc.drawLine(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+6,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+6,
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP
-            );
-            dc.drawLine(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT,
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT+6
-            );
-            dc.drawLine(
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+6,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT,
-                _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
-                _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT+6
+                x,
+                _deviceSpecificView.Y_ZERO_LINE,
+                x,
+                _deviceSpecificView.Y_ZERO_LINE-graphData  as Float * _deviceSpecificView.GRAPH_WIDTH_MULTIPLIER
             );
         }
+
+        if (_stepsToShowInGraph > 96) {
+            timeText = (_stepsToShowInGraph / 96) + "days";
+        }
+
+        _deviceSpecificView.drawTimeText(dc, timeText);
+        var guesstimate = $.guesstimate(_cumulatedDischarge*-1, _stepsToShowInGraph * 15);
+        var y = _deviceSpecificView.STATS_Y_START;
+
+        dc.drawText(
+            _deviceSpecificView.STATS_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+            _maxBattValue.format("%0.2f") + "%",
+            Graphics.TEXT_JUSTIFY_RIGHT
+        );
+        y = y + _deviceSpecificView.STATS_LINE_HIGHT;
+        dc.drawText(
+            _deviceSpecificView.STATS_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+            _minBattValue.format("%0.2f") + "%",
+            Graphics.TEXT_JUSTIFY_RIGHT
+        );
+
+        y = y + _deviceSpecificView.STATS_LINE_HIGHT + _deviceSpecificView.STATS_GROUP_PADDING;
+        dc.drawText(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+                "+",
+                Graphics.TEXT_JUSTIFY_LEFT);
+        dc.drawText(
+            _deviceSpecificView.STATS_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+            _cumulatedCharge.format("%0.2f") + "%",
+            Graphics.TEXT_JUSTIFY_RIGHT
+        );
+
+        y = y + _deviceSpecificView.STATS_LINE_HIGHT;
+        dc.drawText(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+            "-",
+            Graphics.TEXT_JUSTIFY_LEFT
+        );
+        dc.drawText(
+            _deviceSpecificView.STATS_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+            _cumulatedDischarge.format("%0.2f") + "%",
+            Graphics.TEXT_JUSTIFY_RIGHT
+        );
+
+        y = y + _deviceSpecificView.STATS_LINE_HIGHT + _deviceSpecificView.STATS_GROUP_PADDING;
+        dc.drawText(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+            "->",
+            Graphics.TEXT_JUSTIFY_LEFT
+        );
+        dc.drawText(
+            _deviceSpecificView.STATS_X_ALLINGMENT,
+            y,
+            _deviceSpecificView.STATS_FONT,
+            $.guesstimateFormat(guesstimate),
+            Graphics.TEXT_JUSTIFY_RIGHT
+        );
+
+        // draw min/max symbol
+        dc.drawLine(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+3,
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT+3
+        );
+        dc.drawLine(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+6,
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP
+        );
+        dc.drawLine(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+6,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+6,
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP
+        );
+        dc.drawLine(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT,
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT+6
+        );
+        dc.drawLine(
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+6,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT,
+            _deviceSpecificView.STATS_ICON_X_ALLINGMENT+3,
+            _deviceSpecificView.STATS_MIN_MAX_ARROW_TOP+_deviceSpecificView.STATS_LINE_HIGHT+6
+        );
     }
 
     public function getPartOfStorageBuffer(steps as Integer) as Array<Float> {


### PR DESCRIPTION
A user reported that the screen is black when starting the app on a Forerunner 955.
For some reason garmin calls `onUpdate` twice at the start of a view, I tried to "optimize" the code to avoid the double drawing, but maybe its the source of the trouble with the Forerunner 955